### PR TITLE
made changes to algolia index

### DIFF
--- a/bookstore-scrapper/algolia/updateAlgoliaIndex.ts
+++ b/bookstore-scrapper/algolia/updateAlgoliaIndex.ts
@@ -12,6 +12,12 @@ interface AlgoliaEntry {
   entry: Book | Course;
 }
 
+enum UNWANTED_ENTRY_KEYWORD {
+  UNWANTED_ISBN_ENDING = "B",
+  ETEXT = "ETEXT",
+  LAB_MANUAL = "LAB MANUAL",
+}
+
 const searchableAttributes: string[] = [
   "entry.dept.abbreviation",
   "entry.dept.name",
@@ -20,7 +26,17 @@ const searchableAttributes: string[] = [
   "entry.isbn",
 ];
 
-const rankings: string[] = ["exact", "words", "proximity"];
+const rankings: string[] = [
+  "asc(entry.code)",
+  "asc(entry.dept.abbreviation)",
+  "asc(entry.dept.name)",
+  "attribute",
+  "typo",
+  "words",
+  "proximity",
+  "exact",
+  "custom",
+];
 
 export const getAlgoliaObject = async (): Promise<AlgoliaEntry[]> => {
   const dbBooks: Book[] = await prisma.book.findMany();
@@ -31,13 +47,25 @@ export const getAlgoliaObject = async (): Promise<AlgoliaEntry[]> => {
     },
   });
 
-  const algoliaBookEntries: AlgoliaEntry[] = dbBooks.map((book: Book) => {
-    const algoliaBookEntry: AlgoliaEntry = {
-      type: EntryType.BOOK,
-      entry: book,
-    };
-    return algoliaBookEntry;
-  });
+  const algoliaBookEntries: AlgoliaEntry[] = dbBooks
+    .filter((book) => {
+      return (
+        /* Remove campus store entries that are not related to physical books
+        or provide a note to users. */
+        !(
+          book.isbn.endsWith(UNWANTED_ENTRY_KEYWORD.UNWANTED_ISBN_ENDING) ||
+          book.name.startsWith(UNWANTED_ENTRY_KEYWORD.ETEXT) ||
+          book.name.includes(UNWANTED_ENTRY_KEYWORD.LAB_MANUAL)
+        )
+      );
+    })
+    .map((book: Book) => {
+      const algoliaBookEntry: AlgoliaEntry = {
+        type: EntryType.BOOK,
+        entry: book,
+      };
+      return algoliaBookEntry;
+    });
 
   const algoliaCourseEntries: AlgoliaEntry[] = dbCourses.map(
     (course: Course) => {

--- a/bookstore-scrapper/algolia/updateAlgoliaIndex.ts
+++ b/bookstore-scrapper/algolia/updateAlgoliaIndex.ts
@@ -13,7 +13,7 @@ interface AlgoliaEntry {
 }
 
 enum UNWANTED_ENTRY_KEYWORD {
-  UNWANTED_ISBN_ENDING = "B",
+  ISBN_ENDING_WITH_B = "B",
   ETEXT = "ETEXT",
   LAB_MANUAL = "LAB MANUAL",
 }


### PR DESCRIPTION
This PR includes changes to the algolia search experience including the removal of unwanted entries and an update to the ranking and sorting settings.

**Items that will be removed from Algolia to improve the search experience:**

1. Book ISBNs ending with "B" 
2. Names starting with (not including) "ETEXT" or including "LAB MANUAL".

**Note that all current entries ending with ISBN "B" are one of the following:**

- START WITH "ETEXT"
- NOTE ABOUT THE UNAVAILABILITY OF A TEXTBOOK FOR THE COURSE
- MOLECULAR MODEL SET
- NOTE ABOUT AVAILABILITY OF COURSE MATERIAL OUTSIDE CAMPUS STORE
- GO TO CLASS FOR INSTRUCTION

**The only item that is not the same as the above is for the course GLF 108:**

- GLF 108 GOLF COURSE TOPOGRAPHIC BASE PLAN MAP 27

The [course website](https://www.mcmastercce.ca/courseoutline/870/golf-course-design-construction-%E2%80%93-turf-management-c21-online?x=3XrI32oZIQkeGRa07A85dX4jFX7ohxKY) does not say anything about a book, and the entry does not have a price or any additional information in the campus store. It will be removed.

Other weird items you might see are ones starting with "LL PKG" and "LL". Those should be included, since they are part of physical book packages (usually offered with an ETEXT copy or other course content).